### PR TITLE
Fix NullReference in Todo deletion

### DIFF
--- a/DotNetCoreSqlDb/Controllers/TodosController.cs
+++ b/DotNetCoreSqlDb/Controllers/TodosController.cs
@@ -152,8 +152,11 @@ namespace DotNetCoreSqlDb.Controllers
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             var todo = await _context.Todo.FindAsync(id);
-            _context.Todo.Remove(todo);
-            await _context.SaveChangesAsync();
+            if (todo != null)
+            {
+                _context.Todo.Remove(todo);
+                await _context.SaveChangesAsync();
+            }
             return RedirectToAction(nameof(Index));
         }
 


### PR DESCRIPTION
## Summary
- fix potential null reference in `DeleteConfirmed` action

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684405a27e488322be1fecc025b18614